### PR TITLE
#9: run `transitionReducer` also when merging a user-init change (closes #9)

### DIFF
--- a/run.js
+++ b/run.js
@@ -230,7 +230,7 @@ export default function run({
   onBrowserChange((renderElement: t.Function, fromRouter: t.Object) => {
     if (_newState) {
       log('browser change: user initiated');
-      const newState = mergeStateAndBrowserState(_newState, fromRouter);
+      const newState = transitionReducer(mergeStateAndBrowserState(_newState, fromRouter));
       _newState = null;
       state.next(newState);
     } else {


### PR DESCRIPTION
Issue #9

## Test Plan

### tests performed

- tested on lexdoit, we can now always have the latest computed `isStaticPage` value, even after a browser transition (e.g. click on back)
- tested briefly it doesn't break stuff on OD, pinning the old version there anyway

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
