### PR TITLE
#17: remove `compomentWillMount` in favor of state initializer + `componentDidMount` (closes #17)

### DIFF
--- a/src/connect.js
+++ b/src/connect.js
@@ -84,12 +84,17 @@ export default function connect(select = identity, {
 
       static displayName = displayName;
 
-      constructor(props) {
-        super(props);
-        this.state = {};
+      constructor(props, context) {
+        super(props, context);
+        const value = context.state.value;
+        if (isValidState(value)) {
+          this.state = filterKeys(value);
+        } else {
+          this.state = {};
+        }
       }
 
-      componentWillMount() {
+      componentDidMount() {
         this._subscription = this.context.state::filter(isValidState)::map(filterKeys).subscribe(::this.setState);
       }
 


### PR DESCRIPTION
Issue #17

## Test Plan

### tests performed

tested manually on qia, all seems to behave the same

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
