### PR TITLE
#45: add inline documentation on the main function signatures (closes #45)

### DIFF
--- a/src/connect.tsx
+++ b/src/connect.tsx
@@ -42,15 +42,15 @@ export type ConnectConfig = {
    */
   pure?: boolean;
   /**
-   * [DEPRECATED]
    * Do not rerender if received state is not valid.
    * default: true
-   * */
+   * @deprecated not needed anymore (it was needed with React Router)
+   */
   filterValid?: boolean;
   /**
-   * [DEPRECATED]
    * Do not pass down some of the received props.
    * default: []
+   * @deprecated not needed anymore (it was handy with React Router)
    */
   killProps?: string[];
 };
@@ -65,7 +65,7 @@ export type ConnectDecorator<S extends ST, Decl extends keyof S> = <P>(
   /**
    * Component to connect.
    * Will be rendered adding the declared keys from state and `transition` as props
-   * */
+   */
   C: DecoratedComponent<S, P>
 ) => ConnectedComponent<P, Decl>;
 export type ConnectDeclaration<S extends ST, Decl extends keyof S> = ConnectDecorator<S, Decl> &
@@ -74,12 +74,12 @@ export type ConnectDeclaration<S extends ST, Decl extends keyof S> = ConnectDeco
   });
 export type Connect<S extends ST> = <Decl extends keyof S>(
   /**
-   * keys of State to be connected and passed to this container
+   * Keys of State to be connected and passed to this container
    */
   decl: Decl[],
   /**
-   * optinal additional configurations
-  */
+   * Additional configurations
+   */
   config?: ConnectConfig
 ) => ConnectDeclaration<S, Decl>;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,8 +7,10 @@ const isStrictInterface = (x: any) => {
   return t.isType(x) && x.meta.kind === 'interface' && x.meta.strict === true;
 };
 
+/**
+ * @param stateType tcomb interface for State type
+ */
 export default function<S extends StateT>(
-  /** tcomb interface for State type */
   stateType: StateTcombType<S>
 ): {
   run: Run<S>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,15 @@
 import * as t from 'tcomb';
 import run, { Run } from './run';
 import connect, { Connect } from './connect';
-import { StateT } from './StateT';
+import { StateT, StateTcombType } from './StateT';
 
 const isStrictInterface = (x: any) => {
   return t.isType(x) && x.meta.kind === 'interface' && x.meta.strict === true;
 };
 
 export default function<S extends StateT>(
-  stateType: t.Interface<S>
+  /** tcomb interface for State type */
+  stateType: StateTcombType<S>
 ): {
   run: Run<S>;
   appState: t.Interface<S>;

--- a/src/run.ts
+++ b/src/run.ts
@@ -26,21 +26,21 @@ export type StateSubject<S extends StateT> = BehaviorSubject<S>;
 export type RunParams<S extends StateT> = {
   /**
    * Initial state value
-   * */
+   */
   initialState: S;
   /**
    * Apply custom transformations after every state transition,
    * before pushing the updated value to connected components
-   * */
+   */
   transitionReducer?: TransitionFunctionFunction<S>;
   /**
    * Subscribe to every state change... in case you need it
-   * */
+   */
   subscribe?: (state: S) => void;
   /**
    * App own initialization calback... in case you need it.
    * Has access access the state Rx.Subject and the `transition` function
-   * */
+   */
   init?: (state: StateSubject<S>, transition: TransitionFunction<S>) => void;
   /**
    * Whether to serialize (sync to browser) a state key or not.
@@ -52,25 +52,25 @@ export type RunParams<S extends StateT> = {
    * Whether a patch should be serialized (synced to browser) as a new history item
    * (return true) or replace the current history item (return false).
    * default: always push
-   * */
+   */
   shouldBrowserPatchBePushedOrReplaced?: (oldState: S, newState: S) => boolean;
   /**
-   * Optionally pass additional react context via the returned Provider
-   * */
+   * Pass additional react context via the returned Provider
+   */
   provideContext?: {
     /**
      * Context values to be passed to the components tree
-     * */
+     */
     values: ProvideContext;
     /**
      * Types of the passed context values (defined as PropTypes map)
-     * */
+     */
     types?: ProvideContextTypes;
   };
   /**
-   * Optionally pass a custom history (different from browser history).
+   * Pass a custom history (different from browser history).
    * This is only for tests at the moment, but could be necessary for SSR too in the future
-   * */
+   */
   history?: History;
 };
 export type RunReturn = /**

--- a/src/run.ts
+++ b/src/run.ts
@@ -24,17 +24,60 @@ export type StateContextWrapper = React.ComponentType<{}>;
 export type StateSubject<S extends StateT> = BehaviorSubject<S>;
 
 export type RunParams<S extends StateT> = {
+  /**
+   * Initial state value
+   * */
   initialState: S;
+  /**
+   * Apply custom transformations after every state transition,
+   * before pushing the updated value to connected components
+   * */
   transitionReducer?: TransitionFunctionFunction<S>;
-  subscribe?: (s: S) => void;
-  init?: (s: StateSubject<S>, t: TransitionFunction<S>) => void;
-  shouldSerializeKey?: (k: keyof S) => boolean;
+  /**
+   * Subscribe to every state change... in case you need it
+   * */
+  subscribe?: (state: S) => void;
+  /**
+   * App own initialization calback... in case you need it.
+   * Has access access the state Rx.Subject and the `transition` function
+   * */
+  init?: (state: StateSubject<S>, transition: TransitionFunction<S>) => void;
+  /**
+   * Whether to serialize (sync to browser) a state key or not.
+   * Should return true if `key` should be serialized, false if not.
+   * default: serialize all keys
+   */
+  shouldSerializeKey?: (key: keyof S) => boolean;
+  /**
+   * Whether a patch should be serialized (synced to browser) as a new history item
+   * (return true) or replace the current history item (return false).
+   * default: always push
+   * */
   shouldBrowserPatchBePushedOrReplaced?: (oldState: S, newState: S) => boolean;
-  provideContext?: ProvideContext;
-  provideContextTypes?: ProvideContextTypes;
+  /**
+   * Optionally pass additional react context via the returned Provider
+   * */
+  provideContext?: {
+    /**
+     * Context values to be passed to the components tree
+     * */
+    values: ProvideContext;
+    /**
+     * Types of the passed context values (defined as PropTypes map)
+     * */
+    types?: ProvideContextTypes;
+  };
+  /**
+   * Optionally pass a custom history (different from browser history).
+   * This is only for tests at the moment, but could be necessary for SSR too in the future
+   * */
   history?: History;
 };
-export type RunReturn = Promise<StateContextWrapper>;
+export type RunReturn = /**
+ * Context provider used by `connect`. Should be used in the main `ReactDOM.render()` call.
+ */ Promise<
+  StateContextWrapper
+>;
 export type Run<S extends StateT> = (p: RunParams<S>) => RunReturn;
 
 function parseAndPickValidStateKeys<S extends StateT>(stateType: StateTcombType<S>, b: BrowserState): S {
@@ -50,35 +93,13 @@ const mergeStateAndBrowserState = <S extends StateT>(stateType: StateTcombType<S
 const transitionReducerIdentity = <S extends StateT>(s: S) => s;
 
 export default <S extends StateT>(stateType: StateTcombType<S>) => ({
-  // initial state
   initialState,
-
-  // apply custom transformations after every state transition
   transitionReducer: _transitionReducer = transitionReducerIdentity,
-
-  // subscribe to every state change
-  // ...in case you need it
   subscribe = () => {},
-
-  // app own initialization calback
-  // ...in case you need it
-  // has access access the state Rx.Subject and
-  // the transition function (documented elsewhere)
   init = () => {},
-
-  // whether to serialize (sync to browser) a state key or not
   shouldSerializeKey = () => true,
-
-  // whether a patch should be serialized (synced to browser) as a new history item
-  // (true and default) or replace the current history item (false)
   shouldBrowserPatchBePushedOrReplaced = () => true,
-
-  // optionally pass additional react context via the Provider
-  provideContext = {},
-  provideContextTypes = {},
-
-  // optionally pass a custom history (different from browser history)
-  // this is only for tests at the moment, but could be necessary for SSR too in the future
+  provideContext: { values: provideContext = {}, types: provideContextTypes = {} } = {},
   history
 }: RunParams<S>): RunReturn => {
   const transitionReducer: TransitionFunctionFunction<S> = (s: S) => omitNils<S>(_transitionReducer(s));
@@ -116,6 +137,7 @@ export default <S extends StateT>(stateType: StateTcombType<S>) => ({
 
   // wait to receive the first browser state before resolving, so that users can
   // render with something meaningful at hand
+  // TODO(gio): consider removing asynchronicity here (see TODO below)
   let _bootstrapped = false;
 
   const mergeStateAndValidBrowserState = mergeStateAndBrowserState<S>(stateType);


### PR DESCRIPTION
Closes #45

ended up being breaking because of the `provideContext` api change

## Test Plan

### tests performed

tested docs using `examples/basic` file

> A Test Plan is used to show what you tested to make sure your code works fine. You should write here all that you did to test, and provide some results of your testing.

> These results can be screenshots, query results, or even just pointers to unit tests that successfully passed.}

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
