### PR TITLE
allow defining and parsing nested paths and path params (closes #42)

### DIFF
--- a/examples/basic.tsx
+++ b/examples/basic.tsx
@@ -20,20 +20,11 @@ const { run, connect } = make<State>(State);
 
 class _MyComponent extends React.Component<{ view: State['view'] }> {
   render() {
-    return (
-      <div>
-        {this.props.view}
-      </div>
-    );
+    return <div>{this.props.view}</div>;
   }
 }
 const MyComponent = connect(['view'])(_MyComponent);
 
 run({ initialState: { view: 'foo' } }).then(Provider => {
-  ReactDOM.render(
-    <Provider>
-      {() => <MyComponent />}
-    </Provider>,
-    document.body
-  );
+  ReactDOM.render(<Provider>{() => <MyComponent />}</Provider>, document.body);
 });

--- a/package.json
+++ b/package.json
@@ -27,36 +27,36 @@
   },
   "homepage": "https://github.com/buildo/state#readme",
   "dependencies": {
-    "@types/history": "^4.6.0",
-    "@types/prop-types": "^15.5.1",
-    "history": "^4.6.3",
-    "lodash": "^4.17.4",
-    "prop-types": "^15.5.10",
-    "qs": "^6.5.0",
-    "rxjs": "^5.4.2",
-    "tcomb": "^3.2.22"
+    "@types/history": "4.6.0",
+    "@types/prop-types": "15.5.1",
+    "history": "4.6.3",
+    "lodash": "4.17.4",
+    "prop-types": "15.5.10",
+    "qs": "6.5.1",
+    "rxjs": "5.4.2",
+    "tcomb": "3.2.24"
   },
   "peerDependencies": {
     "react": "^15"
   },
   "devDependencies": {
     "@types/debug": "0.0.30",
-    "@types/jest": "^20.0.7",
-    "@types/lodash": "^4.14.73",
-    "@types/qs": "^6.5.0",
+    "@types/jest": "20.0.7",
+    "@types/lodash": "4.14.73",
+    "@types/qs": "6.5.1",
     "@types/react": "^15",
     "@types/react-dom": "^15",
-    "@types/react-test-renderer": "^15.5.2",
-    "jest": "^20.0.4",
+    "@types/react-test-renderer": "15.5.2",
+    "jest": "20.0.4",
     "prettier": "^1.5.3",
     "react": "^15",
     "react-dom": "^15",
-    "react-test-renderer": "^15.6.1",
+    "react-test-renderer": "15.6.1",
     "sinon": "^1.17.4",
     "smooth-release": "^8.0.4",
     "ts-jest": "^20.0.10",
-    "typelevel-ts": "^0.1.3",
-    "typescript": "^2.4.2"
+    "typelevel-ts": "0.1.3",
+    "typescript": "2.4.2"
   },
   "jest": {
     "transform": {

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -5,6 +5,7 @@ import * as qs from 'qs';
 import find = require('lodash/find');
 import mapValues = require('lodash/mapValues');
 import omit = require('lodash/omit');
+import difference = require('lodash/difference');
 
 export type PathConfig<S extends BrowserState> = {
   deserialize: (pathname: string) => Partial<S> | null;
@@ -23,23 +24,48 @@ const defaultNoPath: PathConfig<BrowserState> = {
   pick: s => ({ view: s.view })
 };
 
-function parsePathname(pathname: string, paths: PathConfigs<BrowserState>): Partial<BrowserState> {
-  const path = find(paths, p => Boolean(p.deserialize(pathname))) || defaultNoPath;
-  return path.deserialize(pathname)!;
+function pathnameToPathConfig(pathname: string, paths: PathConfigs<BrowserState>): PathConfig<BrowserState> {
+  return find(paths, p => Boolean(p.deserialize(pathname))) || defaultNoPath;
+}
+
+function locationToPathname(location?: Location): string {
+  return location ? trim(location.pathname, ' /') : '';
+}
+
+function locationToPathConfig(paths: PathConfigs<BrowserState>, location?: Location): PathConfig<BrowserState> {
+  return pathnameToPathConfig(locationToPathname(location), paths);
+}
+
+function parsePathname(paths: PathConfigs<BrowserState>, location?: Location): Partial<BrowserState> {
+  return locationToPathConfig(paths, location).deserialize(locationToPathname(location))!;
 }
 
 // export is for tests only
 // TODO(gio): `location` here is optional just because (I think)
 // it can be undefined in some tests using `memoryHistory`
 export function parseBrowserState(paths: PathConfigs<BrowserState>, location?: Location): BrowserState {
-  const pathState = parsePathname(location ? trim(location.pathname, ' /') : '', paths);
+  const pathState = parsePathname(paths, location);
   const s = location ? qs.parse(trim(location.search, ' ?')) : {};
   return { ...s, ...pathState };
 }
 
+function cleanupPathParams(
+  s: BrowserState,
+  currentPath: PathConfig<BrowserState>,
+  nextPath: PathConfig<BrowserState>
+): BrowserState {
+  const currentPathParamKeys = Object.keys(currentPath.pick(s));
+  const nextPathParamKeys = Object.keys(nextPath.pick(s));
+  return omit(s, difference(currentPathParamKeys, nextPathParamKeys));
+}
+
+function browserStateToPathConfig(s: BrowserState, paths: PathConfigs<BrowserState>): PathConfig<BrowserState> {
+  return find(paths, p => p.is(s)) || defaultNoPath;
+}
+
 // export is for tests only
 export function serializeBrowserState(s: BrowserState, paths: PathConfigs<BrowserState>): Partial<Location> {
-  const path = find(paths, p => p.is(s)) || defaultNoPath;
+  const path = browserStateToPathConfig(s, paths);
   const pathState = path.pick(s);
   const pathname = `/${path.serialize(mapValues(pathState, encodeURIComponent))}`;
   const search = `?${qs.stringify(omit(s, Object.keys(pathState)))}`; // will encode URI by default
@@ -47,16 +73,23 @@ export function serializeBrowserState(s: BrowserState, paths: PathConfigs<Browse
 }
 
 export default function(paths: PathConfigs<BrowserState> = [], history: History = createBrowserHistory()) {
+  let currentPath = locationToPathConfig(paths, history.location);
+
   function syncToBrowser(s: BrowserState, push: boolean = true): void {
     (push ? history.push : history.replace)(serializeBrowserState(s, paths));
   }
 
   function onBrowserChange(callback: (s: BrowserState, action: Action) => void): void {
     history.listen((location, action) => {
+      currentPath = locationToPathConfig(paths, location);
       callback(parseBrowserState(paths, location), action);
     });
     callback(parseBrowserState(paths, history.location), 'PUSH');
   }
 
-  return { syncToBrowser, onBrowserChange };
+  function dryRunBrowserTransition<S extends BrowserState>(s: S): S {
+    return cleanupPathParams(s, currentPath, browserStateToPathConfig(s, paths)) as S;
+  }
+
+  return { syncToBrowser, onBrowserChange, dryRunBrowserTransition };
 }

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -59,13 +59,13 @@ function cleanupPathParams(
   return omit(s, difference(currentPathParamKeys, nextPathParamKeys));
 }
 
-function browserStateToPathConfig(s: BrowserState, paths: PathConfigs<BrowserState>): PathConfig<BrowserState> {
+function browserStateToPathConfig(paths: PathConfigs<BrowserState>, s: BrowserState): PathConfig<BrowserState> {
   return find(paths, p => p.is(s)) || defaultNoPath;
 }
 
 // export is for tests only
-export function serializeBrowserState(s: BrowserState, paths: PathConfigs<BrowserState>): Partial<Location> {
-  const path = browserStateToPathConfig(s, paths);
+export function serializeBrowserState(paths: PathConfigs<BrowserState>, s: BrowserState): Partial<Location> {
+  const path = browserStateToPathConfig(paths, s);
   const pathState = path.pick(s);
   const pathname = `/${path.serialize(mapValues(pathState, encodeURIComponent))}`;
   const search = `?${qs.stringify(omit(s, Object.keys(pathState)))}`; // will encode URI by default
@@ -76,7 +76,7 @@ export default function(paths: PathConfigs<BrowserState> = [], history: History 
   let currentPath = locationToPathConfig(paths, history.location);
 
   function syncToBrowser(s: BrowserState, push: boolean = true): void {
-    (push ? history.push : history.replace)(serializeBrowserState(s, paths));
+    (push ? history.push : history.replace)(serializeBrowserState(paths, s));
   }
 
   function onBrowserChange(callback: (s: BrowserState, action: Action) => void): void {
@@ -88,7 +88,7 @@ export default function(paths: PathConfigs<BrowserState> = [], history: History 
   }
 
   function dryRunBrowserTransition<S extends BrowserState>(s: S): S {
-    return cleanupPathParams(s, currentPath, browserStateToPathConfig(s, paths)) as S;
+    return cleanupPathParams(s, currentPath, browserStateToPathConfig(paths, s)) as S;
   }
 
   return { syncToBrowser, onBrowserChange, dryRunBrowserTransition };

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,40 +1,61 @@
 import { History, Location, Action } from 'history';
 import createBrowserHistory from 'history/createBrowserHistory';
 import trim = require('lodash/trim');
-import omit = require('lodash/omit');
 import * as qs from 'qs';
+import find = require('lodash/find');
+import mapValues = require('lodash/mapValues');
+import omit = require('lodash/omit');
 
-// TODO: below, ignoring path params for the moment
-// there's only `view` which is the whole `pathname` from history perspective
+export type PathConfig<S extends BrowserState> = {
+  deserialize: (pathname: string) => Partial<S> | null;
+  serialize: (state: Partial<S>) => string;
+  is: (state: S) => boolean;
+  pick: (state: S) => Partial<S>;
+};
+export type PathConfigs<S extends BrowserState> = Array<PathConfig<S>>;
 
 export type BrowserState = { [k: string]: string } & { view: string };
+
+const defaultNoPath: PathConfig<BrowserState> = {
+  deserialize: (pathname: string) => ({ view: pathname }),
+  serialize: ({ view: pathname }: BrowserState) => pathname,
+  is: () => true,
+  pick: s => ({ view: s.view })
+};
+
+function parsePathname(pathname: string, paths: PathConfigs<BrowserState>): Partial<BrowserState> {
+  const path = find(paths, p => Boolean(p.deserialize(pathname))) || defaultNoPath;
+  return path.deserialize(pathname)!;
+}
 
 // export is for tests only
 // TODO(gio): `location` here is optional just because (I think)
 // it can be undefined in some tests using `memoryHistory`
-export function parseBrowserState(location?: Location): BrowserState {
-  const view = location ? trim(location.pathname, ' /') : '';
+export function parseBrowserState(paths: PathConfigs<BrowserState>, location?: Location): BrowserState {
+  const pathState = parsePathname(location ? trim(location.pathname, ' /') : '', paths);
   const s = location ? qs.parse(trim(location.search, ' ?')) : {};
-  return { ...s, view };
+  return { ...s, ...pathState };
 }
 
 // export is for tests only
-export function serializeBrowserState(s: BrowserState): Partial<Location> {
-  const pathname = `/${encodeURIComponent(s.view)}`;
-  const search = `?${qs.stringify(omit(s, ['view']))}`; // will encode URI by default
+export function serializeBrowserState(s: BrowserState, paths: PathConfigs<BrowserState>): Partial<Location> {
+  const path = find(paths, p => p.is(s)) || defaultNoPath;
+  const pathState = path.pick(s);
+  const pathname = `/${path.serialize(mapValues(pathState, encodeURIComponent))}`;
+  const search = `?${qs.stringify(omit(s, Object.keys(pathState)))}`; // will encode URI by default
   return { pathname, search };
 }
 
-export default function(history: History = createBrowserHistory()) {
+export default function(paths: PathConfigs<BrowserState> = [], history: History = createBrowserHistory()) {
   function syncToBrowser(s: BrowserState, push: boolean = true): void {
-    (push ? history.push : history.replace)(serializeBrowserState(s));
+    (push ? history.push : history.replace)(serializeBrowserState(s, paths));
   }
 
   function onBrowserChange(callback: (s: BrowserState, action: Action) => void): void {
     history.listen((location, action) => {
-      callback(parseBrowserState(location), action);
+      callback(parseBrowserState(paths, location), action);
     });
-    callback(parseBrowserState(history.location), 'PUSH');
+    callback(parseBrowserState(paths, history.location), 'PUSH');
   }
 
   return { syncToBrowser, onBrowserChange };

--- a/src/connect.tsx
+++ b/src/connect.tsx
@@ -174,7 +174,7 @@ export default function makeConnect<S extends ST>(stateType: t.Interface<S>): Co
           const props = {
             // state first: connected props are overridable by "actual" (passed) props
             // it's useful for av@queries, av@commands
-            ...this.state as any, // TODO(typo): spread types can only be created from object types
+            ...(this.state as any), // TODO(typo): spread types can only be created from object types
             ...omit(this.props as any, killProps), // TODO(typo): spread types can only be created from object types
             transition: this.context.transition
           };
@@ -184,7 +184,7 @@ export default function makeConnect<S extends ST>(stateType: t.Interface<S>): Co
     };
 
     (decorator as ConnectDeclaration<S, Decl>).Type = {
-      ...pick(stateType.meta.props, decl) as any, // TODO(typo): ugh
+      ...(pick(stateType.meta.props, decl) as any), // TODO(typo): ugh
       transition: t.Function
     };
     return decorator as ConnectDeclaration<S, Decl>;

--- a/src/run.ts
+++ b/src/run.ts
@@ -110,7 +110,7 @@ export default <S extends StateT>(stateType: StateTcombType<S>) => ({
   const state = new BehaviorSubject(stateType(initialState));
   state.subscribe(subscribe);
 
-  const { syncToBrowser: _syncToBrowser, onBrowserChange } = mkBrowser(paths, history);
+  const { syncToBrowser: _syncToBrowser, onBrowserChange, dryRunBrowserTransition } = mkBrowser(paths, history);
 
   const stringify = _stringify(stateType);
 
@@ -130,7 +130,8 @@ export default <S extends StateT>(stateType: StateTcombType<S>) => ({
     stateSubject: state,
     stateType,
     syncToBrowser,
-    transitionReducer
+    transitionReducer,
+    dryRunBrowserTransition
   });
 
   const { values: provideContextValues = {}, types: provideContextTypes = {} } = provideContext || {};
@@ -157,7 +158,10 @@ export default <S extends StateT>(stateType: StateTcombType<S>) => ({
           // if not pushing (so either 'POP' or 'REPLACE') it means that either:
           // - POP: user is using back via browser
           // - REPLACE: we are replacing an old history entry not valid anymore (see code below here)
-          const { newState, stateChanged } = dryRunTransition(mergedState, mergedState);
+          const { newState, stateChanged } = (dryRunTransition(mergedState, mergedState) as any) as {
+            newState: S; // TODO(typo)
+            stateChanged: boolean;
+          };
           if (stateChanged) {
             log('syncing (replacing) to browser after a back', 'oldState', mergedState, 'newState', newState);
             state.next(newState);

--- a/src/transition.ts
+++ b/src/transition.ts
@@ -38,8 +38,8 @@ export default function makeTransition<S extends StateT>({
   const dryRunTransition: DryRunTransitionFunction<S> = (state, _transition) => {
     const isTransitionFunction = t.Function.is(_transition);
     const transitionFn = isTransitionFunction
-      ? _transition as TransitionFunctionFunction<S> // TODO(typo): cast
-      : ((() => _transition) as any) as TransitionFunctionFunction<S>; // TODO(typo): cast + removed `t.Object(` check
+      ? (_transition as TransitionFunctionFunction<S>) // TODO(typo): cast
+      : (((() => _transition) as any) as TransitionFunctionFunction<S>); // TODO(typo): cast + removed `t.Object(` check
 
     const patch = transitionFn(state);
 

--- a/test/browser.test.ts
+++ b/test/browser.test.ts
@@ -129,25 +129,25 @@ describe('browser', () => {
 
   describe('serializeBrowserState', () => {
     it('should produce urlencoded pathnames with a single leading /', () => {
-      expect(serializeBrowserState({ view: 'foo' }, []).pathname).toEqual('/foo');
-      expect(serializeBrowserState({ view: '/foo/' }, []).pathname).toEqual('/%2Ffoo%2F');
+      expect(serializeBrowserState([], { view: 'foo' }).pathname).toEqual('/foo');
+      expect(serializeBrowserState([], { view: '/foo/' }).pathname).toEqual('/%2Ffoo%2F');
     });
 
     it('should produce urlencoded searches with a single leading ?', () => {
-      expect(serializeBrowserState({ view: 'foo', foo: 'foo', bar: 'bar' }, []).search).toBe('?foo=foo&bar=bar');
-      expect(serializeBrowserState({ view: 'foo', '?foo': 'foo', bar: 'bar' }, []).search).toBe('?%3Ffoo=foo&bar=bar');
+      expect(serializeBrowserState([], { view: 'foo', foo: 'foo', bar: 'bar' }).search).toBe('?foo=foo&bar=bar');
+      expect(serializeBrowserState([], { view: 'foo', '?foo': 'foo', bar: 'bar' }).search).toBe('?%3Ffoo=foo&bar=bar');
     });
 
     it('should serialize configured paths', () => {
-      expect(serializeBrowserState({ view: 'users', userId: '10' }, [userDetailPathConfig]).pathname).toBe('/users/10');
+      expect(serializeBrowserState([userDetailPathConfig], { view: 'users', userId: '10' }).pathname).toBe('/users/10');
     });
 
     it('should not serialize configured path params as part of search', () => {
-      expect(serializeBrowserState({ view: 'users', userId: '10' }, [userDetailPathConfig]).search).toBe('?');
+      expect(serializeBrowserState([userDetailPathConfig], { view: 'users', userId: '10' }).search).toBe('?');
     });
 
     it('should serialize with default path in case of no match', () => {
-      expect(serializeBrowserState({ view: 'foo', userId: '10' }, [userDetailPathConfig]).pathname).toBe('/foo');
+      expect(serializeBrowserState([userDetailPathConfig], { view: 'foo', userId: '10' }).pathname).toBe('/foo');
     });
   });
 });

--- a/test/browser.test.ts
+++ b/test/browser.test.ts
@@ -1,6 +1,7 @@
 import mkBrowser, { parseBrowserState, serializeBrowserState } from '../src/browser';
 import createMemoryHistory from 'history/createMemoryHistory';
 import { Location } from 'history';
+import omit = require('lodash/omit');
 
 function partialLocation(pl: Partial<Location>): Location {
   return {
@@ -17,7 +18,7 @@ describe('browser', () => {
   describe('syncToBrowser', () => {
     it('should push a new history item if push is true', () => {
       const history = createMemoryHistory();
-      const { syncToBrowser } = mkBrowser(history);
+      const { syncToBrowser } = mkBrowser([], history);
       syncToBrowser({ view: 'foo', foo: 'bar' }, true);
       expect(history.location.pathname).toBe('/foo');
       expect(history.location.search).toBe('?foo=bar');
@@ -26,7 +27,7 @@ describe('browser', () => {
 
     it('should replace the current history item if push is false', () => {
       const history = createMemoryHistory();
-      const { syncToBrowser } = mkBrowser(history);
+      const { syncToBrowser } = mkBrowser([], history);
       syncToBrowser({ view: 'foo', foo: 'bar' }, false);
       expect(history.location.pathname).toBe('/foo');
       expect(history.location.search).toBe('?foo=bar');
@@ -35,7 +36,7 @@ describe('browser', () => {
 
     it('should default to an empty pathname if view param is not provided', () => {
       const history = createMemoryHistory();
-      const { syncToBrowser } = mkBrowser(history);
+      const { syncToBrowser } = mkBrowser([], history);
       syncToBrowser({ foo: 'bar', view: '' }, false);
       expect(history.location.pathname).toBe('/');
     });
@@ -44,7 +45,7 @@ describe('browser', () => {
   describe('onBrowserChange', () => {
     it('should be called synchronously after a syncToBrowser push=true, with action=PUSH', () => {
       const onBrowserChangeSpy = jest.fn();
-      const { syncToBrowser, onBrowserChange } = mkBrowser(createMemoryHistory());
+      const { syncToBrowser, onBrowserChange } = mkBrowser([], createMemoryHistory());
       onBrowserChange(onBrowserChangeSpy);
       expect(onBrowserChangeSpy.mock.calls.length).toBe(1);
       syncToBrowser({ view: 'foo', foo: 'bar' }, true);
@@ -57,7 +58,7 @@ describe('browser', () => {
 
     it('should be called synchronously after a syncToBrowser push=false, with action=REPLACE', () => {
       const onBrowserChangeSpy = jest.fn();
-      const { syncToBrowser, onBrowserChange } = mkBrowser(createMemoryHistory());
+      const { syncToBrowser, onBrowserChange } = mkBrowser([], createMemoryHistory());
       onBrowserChange(onBrowserChangeSpy);
       expect(onBrowserChangeSpy.mock.calls.length).toBe(1);
       syncToBrowser({ view: 'foo', foo: 'bar' }, false);
@@ -71,7 +72,7 @@ describe('browser', () => {
     it('should be called synchronously after a browser back, with action=POP', () => {
       const onBrowserChangeSpy = jest.fn();
       const history = createMemoryHistory();
-      const { syncToBrowser, onBrowserChange } = mkBrowser(history);
+      const { syncToBrowser, onBrowserChange } = mkBrowser([], history);
       onBrowserChange(onBrowserChangeSpy);
       syncToBrowser({ view: 'foo', foo: 'bar' }, false);
       expect(onBrowserChangeSpy.mock.calls.length).toBe(2);
@@ -84,29 +85,70 @@ describe('browser', () => {
     });
   });
 
+  const userDetailPathConfig = {
+    serialize: s => `users/${s.userId}`,
+    deserialize: pathname => {
+      const match = pathname.match(/^users\/(\d+)$/);
+      return match ? { view: 'users', userId: match[1] } : null;
+    },
+    is: ({ view }) => view === 'users',
+    pick: s => ({ view: s.view, userId: s.userId })
+  };
+
   describe('parseBrowserState', () => {
     it('should trim slashes from view param', () => {
-      expect(parseBrowserState(partialLocation({ pathname: '/view//' }))).toEqual({ view: 'view' });
+      expect(parseBrowserState([], partialLocation({ pathname: '/view//' }))).toEqual({ view: 'view' });
     });
 
     it('should trim question marks from search params', () => {
-      expect(parseBrowserState(partialLocation({ search: '??foo=foo&bar=bar' }))).toEqual({
+      expect(parseBrowserState([], partialLocation({ search: '??foo=foo&bar=bar' }))).toEqual({
         view: '',
         foo: 'foo',
         bar: 'bar'
+      });
+    });
+
+    it('should deserialize configured paths', () => {
+      expect(
+        parseBrowserState([userDetailPathConfig], partialLocation({ pathname: '/users/11', search: '?foo=foo' }))
+      ).toEqual({
+        view: 'users',
+        foo: 'foo',
+        userId: '11'
+      });
+    });
+
+    it('should deserialize with default path in case of no match', () => {
+      expect(
+        parseBrowserState([userDetailPathConfig], partialLocation({ pathname: '/bar', search: '?foo=foo' }))
+      ).toEqual({
+        view: 'bar',
+        foo: 'foo'
       });
     });
   });
 
   describe('serializeBrowserState', () => {
     it('should produce urlencoded pathnames with a single leading /', () => {
-      expect(serializeBrowserState({ view: 'foo' }).pathname).toEqual('/foo');
-      expect(serializeBrowserState({ view: '/foo/' }).pathname).toEqual('/%2Ffoo%2F');
+      expect(serializeBrowserState({ view: 'foo' }, []).pathname).toEqual('/foo');
+      expect(serializeBrowserState({ view: '/foo/' }, []).pathname).toEqual('/%2Ffoo%2F');
     });
 
     it('should produce urlencoded searches with a single leading ?', () => {
-      expect(serializeBrowserState({ view: 'foo', foo: 'foo', bar: 'bar' }).search).toBe('?foo=foo&bar=bar');
-      expect(serializeBrowserState({ view: 'foo', '?foo': 'foo', bar: 'bar' }).search).toBe('?%3Ffoo=foo&bar=bar');
+      expect(serializeBrowserState({ view: 'foo', foo: 'foo', bar: 'bar' }, []).search).toBe('?foo=foo&bar=bar');
+      expect(serializeBrowserState({ view: 'foo', '?foo': 'foo', bar: 'bar' }, []).search).toBe('?%3Ffoo=foo&bar=bar');
+    });
+
+    it('should serialize configured paths', () => {
+      expect(serializeBrowserState({ view: 'users', userId: '10' }, [userDetailPathConfig]).pathname).toBe('/users/10');
+    });
+
+    it('should not serialize configured path params as part of search', () => {
+      expect(serializeBrowserState({ view: 'users', userId: '10' }, [userDetailPathConfig]).search).toBe('?');
+    });
+
+    it('should serialize with default path in case of no match', () => {
+      expect(serializeBrowserState({ view: 'foo', userId: '10' }, [userDetailPathConfig]).pathname).toBe('/foo');
     });
   });
 });

--- a/test/browser.test.ts
+++ b/test/browser.test.ts
@@ -1,4 +1,4 @@
-import mkBrowser, { parseBrowserState, serializeBrowserState } from '../src/browser';
+import mkBrowser, { parseBrowserState, serializeBrowserState, PathConfig } from '../src/browser';
 import createMemoryHistory from 'history/createMemoryHistory';
 import { Location } from 'history';
 
@@ -84,12 +84,10 @@ describe('browser', () => {
     });
   });
 
-  const userDetailPathConfig = {
+  const userDetailPathConfig: PathConfig<any> = {
     serialize: s => `users/${s.userId}`,
-    deserialize: pathname => {
-      const match = pathname.match(/^users\/(\d+)$/);
-      return match ? { view: 'users', userId: match[1] } : null;
-    },
+    match: pathname => pathname.match(/^users\/(\d+)$/),
+    deserialize: match => ({ view: 'users', userId: match[1] }),
     is: ({ view }) => view === 'users',
     pick: s => ({ view: s.view, userId: s.userId })
   };

--- a/test/browser.test.ts
+++ b/test/browser.test.ts
@@ -1,7 +1,6 @@
 import mkBrowser, { parseBrowserState, serializeBrowserState } from '../src/browser';
 import createMemoryHistory from 'history/createMemoryHistory';
 import { Location } from 'history';
-import omit = require('lodash/omit');
 
 function partialLocation(pl: Partial<Location>): Location {
   return {

--- a/test/fullstack.test.tsx
+++ b/test/fullstack.test.tsx
@@ -272,10 +272,8 @@ describe('fullstack', () => {
           {
             is: ({ view }) => view === 'view1',
             serialize: s => `products/${s.foo}`,
-            deserialize: pathname => {
-              const match = pathname.match(/^products\/(\w+)$/);
-              return match ? { view: 'view1', foo: match[1] } : null;
-            },
+            match: pathname => pathname.match(/^products\/(\w+)$/),
+            deserialize: ([_, foo]) => ({ view: 'view1', foo }),
             pick: s => ({ view: s.view, foo: s.foo })
           }
         ]
@@ -297,19 +295,15 @@ describe('fullstack', () => {
           {
             is: ({ view }) => view === 'view1',
             serialize: s => `products/${s.foo}${s.baz ? '/yes' : ''}`,
-            deserialize: pathname => {
-              const match = pathname.match(/^products\/(\w+)\/?(yes)?$/);
-              return match ? { view: 'view1', foo: match[1], baz: match[2] === 'yes' ? 'true' : undefined } : null;
-            },
+            match: pathname => pathname.match(/^products\/(\w+)\/?(yes)?$/),
+            deserialize: ([_, foo, baz]) => ({ view: 'view1', foo, baz: baz === 'yes' ? 'true' : undefined }),
             pick: s => ({ view: s.view, foo: s.foo, baz: s.baz })
           },
           {
             is: ({ view }) => view === 'view2',
             serialize: s => `users/${s.bar}${s.baz ? '/yes' : ''}`,
-            deserialize: pathname => {
-              const match = pathname.match(/^users\/(\w+)\/?(yes)?$/);
-              return match ? { view: 'view2', bar: match[1], baz: match[2] === 'yes' ? 'true' : undefined } : null;
-            },
+            match: pathname => pathname.match(/^users\/(\w+)\/?(yes)?$/),
+            deserialize: ([_, bar, baz]) => ({ view: 'view2', bar, baz: baz === 'yes' ? 'true' : undefined }),
             pick: s => ({ view: s.view, bar: s.bar, baz: s.baz })
           }
         ]

--- a/test/prepareTransition.ts
+++ b/test/prepareTransition.ts
@@ -20,7 +20,8 @@ export default function<S extends StateT>({
     stateType,
     stateSubject,
     transitionReducer: identity,
-    syncToBrowser: () => {}
+    syncToBrowser: () => {},
+    dryRunBrowserTransition: s => s
   });
   return { states, transition };
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "strict": true,
     "outDir": "./lib",
     "declaration": true,
     "target": "ES5",


### PR DESCRIPTION
very unhappy with the API (see example usage [here](https://github.com/buildo/gdsm/blob/23168731ce70d1eb9f6085796e8ea17e56dead08/web/src/client/index.base.js#L17-L65) ). Since it's been here for a while, unless you have suggestions, I'd merge it as is for the moment :man_shrugging: 

## test plan
- added some new unit tests
- tested manually here https://github.com/buildo/gdsm/pull/981